### PR TITLE
point sonar at correct test directory

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,6 +6,6 @@ sonar.sources=src,views
 
 sonar.projectName=promise-to-file-web
 sonar.exclusions=**/dist/**, **/coverage/**, **/node_modules/**
-sonar.tests=src, **/test
+sonar.tests=test
 sonar.test.inclusions=**/test/**.spec.*
 sonar.typescript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
As all our tests are stored in tests directory, removing src as location of tests.