### PR TITLE
disable ptf session creation

### DIFF
--- a/src/authentication/middleware/index.ts
+++ b/src/authentication/middleware/index.ts
@@ -8,6 +8,8 @@ export default (req: Request, res: Response, next: NextFunction) => {
 
   if (!req.chSession.isSignedIn()) {
 
+    logger.debug("User not authenticated");
+
     let returnToUrl: string = pageURLs.PROMISE_TO_FILE;
 
     const referringPageURL = req.header("Referer") as string;

--- a/src/authentication/middleware/index.ts
+++ b/src/authentication/middleware/index.ts
@@ -1,5 +1,4 @@
 import { NextFunction, Request, Response } from "express";
-import activeFeature from "../../feature.flag";
 import logger from "../../logger";
 import * as pageURLs from "../../model/page.urls";
 
@@ -9,14 +8,13 @@ export default (req: Request, res: Response, next: NextFunction) => {
 
   if (!req.chSession.isSignedIn()) {
 
-    logger.debug("User not authenticated - redirecting to login screen");
-
     let returnToUrl: string = pageURLs.PROMISE_TO_FILE;
 
     const referringPageURL = req.header("Referer") as string;
 
     // Redirect the user to to the start screen if they weren't already on the PTF journey
     if (referringPageURL === undefined) {
+      logger.debug("User not authenticated and referrer undefined - redirecting to index");
       return res.redirect(pageURLs.PROMISE_TO_FILE);
     }
 
@@ -24,6 +22,7 @@ export default (req: Request, res: Response, next: NextFunction) => {
       returnToUrl = req.originalUrl;
     }
 
+    logger.debug("User not authenticated - redirecting to login screen");
     return res.redirect("/signin?return_to=" + returnToUrl);
   }
 

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -27,5 +27,3 @@ export const INTEGER_PARSE_BASE = 10;
 export const PIWIK_URL = getEnvironmentValue("PIWIK_URL");
 
 export const PIWIK_SITE_ID = getEnvironmentValue("PIWIK_SITE_ID");
-
-export const SESSION_CREATE = "true";

--- a/src/session/middleware/index.ts
+++ b/src/session/middleware/index.ts
@@ -1,9 +1,8 @@
 import Session from "../session";
 import {NextFunction, Request, Response} from "express";
-import {COOKIE_NAME, SESSION_CREATE} from "../../properties";
+import {COOKIE_NAME} from "../../properties";
 import * as redisService from "../../services/redis.service";
 import logger from "../../logger";
-import activeFeature from "../../feature.flag";
 
 declare global {
   namespace Express {
@@ -15,18 +14,13 @@ declare global {
 
 export default async (req: Request, res: Response, next: NextFunction) => {
   const cookieId = req.cookies[COOKIE_NAME];
-  // if there is no cookie, we need to create a new session
-  if (!cookieId && activeFeature(SESSION_CREATE)) {
-    logger.info("No cookie found, creating new session");
-    const session = Session.newInstance();
-    session.setClientSignature(req.get("user-agent") || "", req.ip);
-    await redisService.saveSession(session);
 
-    req.chSession = session;
-    res.cookie(COOKIE_NAME, session.cookieId, {path: "/"});
-  } else {
+  if (cookieId) {
     logger.info("cookie found, loading session from redis: " + cookieId);
     req.chSession = await redisService.loadSession(cookieId);
+  }else {
+    logger.info("No cookie found, using blank session");
+    req.chSession = await redisService.loadSession("");
   }
 
   next();

--- a/src/session/middleware/index.ts
+++ b/src/session/middleware/index.ts
@@ -18,7 +18,7 @@ export default async (req: Request, res: Response, next: NextFunction) => {
   if (cookieId) {
     logger.info("cookie found, loading session from redis: " + cookieId);
     req.chSession = await redisService.loadSession(cookieId);
-  }else {
+  } else {
     logger.info("No cookie found, using blank session");
     req.chSession = await redisService.loadSession("");
   }

--- a/test/authentication/middleware/index.spec.unit.ts
+++ b/test/authentication/middleware/index.spec.unit.ts
@@ -23,6 +23,12 @@ describe("Authentication middleware", () => {
     expect(response.status).toEqual(200);
   });
 
+  it("should redirect to start page if loading start page with trailing slash", async () => {
+    const response = await request(app)
+      .get("/promise-to-file/");
+    expect(response.status).toEqual(200);
+  });
+
   it("should redirect to signin if /promise-to-file/* called and not signed in", async () => {
     setNotSignedIn();
     const response = await request(app)


### PR DESCRIPTION
Disabled session creation and setting a cookie from within the ptf service as this was causing authentication errors, the session and cookie will be created when the user is directed to the sign in service