### PR TITLE
LFA-1250 Call SDK to retrieve company and show error if none is found

### DIFF
--- a/src/controllers/company.number.controller.ts
+++ b/src/controllers/company.number.controller.ts
@@ -4,6 +4,10 @@ import * as errorMessages from "../model/error.messages";
 import {createGovUkErrorData, GovUkErrorData} from "../model/govuk.error.data";
 import * as templatePaths from "../model/template.paths";
 import {ValidationError} from "../model/validation.error";
+import logger from "../logger";
+import {PTFCompanyProfile} from "../model/company.profile";
+import {getCompanyProfile} from "../client/apiclient";
+import {PROMISE_TO_FILE_CHECK_COMPANY} from "../model/page.urls";
 
 // validator middleware that checks for an empty or too long input
 const preValidators = [
@@ -37,6 +41,8 @@ const postValidators = [
 ];
 
 const route = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  logger.debug("Attempt to retrieve and show the company details");
+
   const errors = validationResult(req);
 
   // render errors in the view
@@ -44,14 +50,41 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
     const errorText = errors.array({ onlyFirstError: true })
                             .map((err: ValidationError) => err.msg)
                             .pop() as string;
-    const companyNumberErrorData: GovUkErrorData = createGovUkErrorData(errorText, "#company-number", true, "");
 
-    return res.render(templatePaths.COMPANY_NUMBER, {
-      companyNumberErr: companyNumberErrorData,
-      errorList: [companyNumberErrorData],
-      templateName: templatePaths.COMPANY_NUMBER,
-    });
+    return buildError(res, errorText);
   }
+
+  const companyNumber: string = req.body.companyNumber;
+
+  try {
+    logger.info("Retrieving company profile for company number ${companyNumber}");
+    const token: string = req.chSession.accessToken() as string;
+    const company: PTFCompanyProfile = await getCompanyProfile(companyNumber, token);
+
+    // TODO Place the retrieved company details into the PTF session, once available - covered by task LFA-1332
+
+    return res.redirect(PROMISE_TO_FILE_CHECK_COMPANY);
+  } catch (e) {
+    logger.error("Error fetching company profile for company number ${companyNumber}", e);
+    if (e.status === 404) {
+      buildError(res, errorMessages.COMPANY_NOT_FOUND);
+    } else {
+      return next(e);
+    }
+  }
+};
+
+const buildError = (res: Response, errorMessage: string): void => {
+  const companyNumberErrorData: GovUkErrorData = createGovUkErrorData(
+    errorMessage,
+    "#company-number",
+    true,
+    "");
+  return res.render(templatePaths.COMPANY_NUMBER, {
+    companyNumberErr: companyNumberErrorData,
+    errorList: [companyNumberErrorData],
+    templateName: templatePaths.COMPANY_NUMBER,
+  });
 };
 
 export default [...preValidators, padCompanyNumber, ...postValidators, route];

--- a/src/model/error.messages.ts
+++ b/src/model/error.messages.ts
@@ -3,3 +3,4 @@ export const ERROR_SUMMARY_TITLE: string = "There is a problem";
 export const INVALID_COMPANY_NUMBER: string = "Invalid company number";
 export const NO_COMPANY_NUMBER_SUPPLIED: string = "No company number supplied";
 export const COMPANY_NUMBER_TOO_LONG: string = "Company number too long";
+export const COMPANY_NOT_FOUND: string = "Company number not found";

--- a/src/model/page.urls.ts
+++ b/src/model/page.urls.ts
@@ -1,5 +1,7 @@
 export const ROOT: string = "/";
 export const PROMISE_TO_FILE: string = "/promise-to-file";
 export const COMPANY_NUMBER: string = "/company-number";
+export const CHECK_COMPANY: string = "/check-company";
 
 export const PROMISE_TO_FILE_COMPANY_NUMBER: string = PROMISE_TO_FILE + COMPANY_NUMBER;
+export const PROMISE_TO_FILE_CHECK_COMPANY: string = PROMISE_TO_FILE + CHECK_COMPANY;

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -85,6 +85,13 @@ export default class Session {
     return signInInfo.signedIn as boolean;
   }
 
+  public accessToken(): string | undefined {
+    const signInInfo = unmarshalSignInInfo(this._data);
+    if (signInInfo && signInInfo.accessToken && signInInfo.accessToken.token) {
+      return signInInfo.accessToken.token;
+    }
+  }
+
   /**
    * Generates a new cookie id.
    */

--- a/test/controllers/company.number.controller.spec.unit.ts
+++ b/test/controllers/company.number.controller.spec.unit.ts
@@ -4,15 +4,21 @@ import {loadSession} from "../../src/services/redis.service";
 import {loadMockSession} from "../mock.utils";
 import {COOKIE_NAME} from "../../src/properties";
 import * as pageURLs from "../../src/model/page.urls";
+import {getCompanyProfile} from "../../src/client/apiclient";
+import * as mockUtils from "../mock.utils";
 
 jest.mock("../../src/services/redis.service");
+jest.mock("../../src/client/apiclient");
 
+const COMPANY_NUMBER = "00006400";
 const NO_COMPANY_NUMBER_SUPPLIED = "No company number supplied";
 const INVALID_COMPANY_NUMBER = "Invalid company number";
 const COMPANY_NUMBER_TOO_LONG = "Company number too long";
+const COMPANY_NOT_FOUND: string = "Company number not found";
 
 describe("company number validation tests", () => {
 
+  const mockCompanyProfile: jest.Mock = (getCompanyProfile as unknown as jest.Mock<typeof getCompanyProfile>);
   const mockCacheService = (loadSession as unknown as jest.Mock<typeof loadSession>);
 
   beforeEach(() => {
@@ -74,4 +80,41 @@ describe("company number validation tests", () => {
     expect(response.text).not.toContain(INVALID_COMPANY_NUMBER);
     expect(response.text).toContain(COMPANY_NUMBER_TOO_LONG);
   });
+
+  it("should create an error message when company is not found", async () => {
+    mockCompanyProfile.mockImplementation(() => {
+      throw {
+        message: COMPANY_NOT_FOUND,
+        status: 404,
+      };
+    });
+
+    const response = await request(app)
+      .post(pageURLs.PROMISE_TO_FILE_COMPANY_NUMBER)
+      .set("Accept", "application/json")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({companyNumber: "00012345"});
+
+    expect(response.status).toEqual(200);
+    expect(response).not.toBeUndefined();
+    expect(response.text).not.toContain(NO_COMPANY_NUMBER_SUPPLIED);
+    expect(response.text).not.toContain(INVALID_COMPANY_NUMBER);
+    expect(response.text).not.toContain(COMPANY_NUMBER_TOO_LONG);
+    expect(response.text).toContain(COMPANY_NOT_FOUND);
+  });
+
+  it("should redirect to the check company details screen when company is found", async () => {
+    mockCompanyProfile.mockResolvedValue(mockUtils.getDummyCompanyProfile(true, true));
+
+    const response = await request(app)
+      .post(pageURLs.PROMISE_TO_FILE_COMPANY_NUMBER)
+      .set("Accept", "application/json")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({companyNumber: COMPANY_NUMBER});
+
+    expect(response.header.location).toEqual(pageURLs.PROMISE_TO_FILE_CHECK_COMPANY);
+    expect(response.status).toEqual(302);
+    expect(mockCompanyProfile).toHaveBeenCalledWith(COMPANY_NUMBER, mockUtils.ACCESS_TOKEN);
+  });
+
 });

--- a/test/mock.utils.ts
+++ b/test/mock.utils.ts
@@ -1,6 +1,7 @@
 import * as keys from "../src/session/keys";
 import {loadSession} from "../src/services/redis.service";
 import Session from "../src/session/session";
+import {PTFCompanyProfile} from "../src/model/company.profile";
 
 export const ACCESS_TOKEN = "KGGGUYUYJHHVK1234";
 
@@ -20,4 +21,41 @@ export const loadMockSession = (mockLoadSessionFunction: jest.Mock<typeof loadSe
     };
     return session;
   });
+};
+
+export const COMPANY_NUMBER = "00006400";
+export const COMPANY_NAME = "GIRLS TRUST";
+export const COMPANY_STATUS_ACTIVE = "Active";
+export const COMPANY_STATUS_LIQUIDATED = "liquidated";
+export const COMPANY_TYPE = "Limited";
+export const COMPANY_INC_DATE = "23 September 1973";
+export const HAS_BEEN_LIQUIDATED = false;
+export const HAS_CHARGES = true;
+export const HAS_INSOLVENCY_HISTORY = true;
+export const LINE_1 = "123";
+export const LINE_2 = "street";
+export const POST_CODE = "CF1 123";
+export const ACCOUNTS_NEXT_DUE_DATE = "2019-05-12";
+export const CONFIRMATION_STATEMENT_NEXT_DUE_DATE = "2019-09-03";
+export const EMAIL = "demo@ch.gov.uk";
+
+export const getDummyCompanyProfile = (isOverdue: boolean, isActive): PTFCompanyProfile => {
+  return {
+    accountingPeriodEndOn: ACCOUNTS_NEXT_DUE_DATE,
+    accountingPeriodStartOn: ACCOUNTS_NEXT_DUE_DATE,
+    accountsDue: ACCOUNTS_NEXT_DUE_DATE,
+    address: {
+      line_1: LINE_1,
+      line_2: LINE_2,
+      postCode: POST_CODE,
+    },
+    companyName: COMPANY_NAME,
+    companyNumber: COMPANY_NUMBER,
+    companyStatus: isActive ? COMPANY_STATUS_ACTIVE : COMPANY_STATUS_LIQUIDATED,
+    companyType: COMPANY_TYPE,
+    confirmationStatementDue: CONFIRMATION_STATEMENT_NEXT_DUE_DATE,
+    incorporationDate: COMPANY_INC_DATE,
+    isAccountsOverdue: isOverdue,
+    isConfirmationStatementOverdue: isOverdue,
+  };
 };


### PR DESCRIPTION
This change will redirect to the check company details screen if the SDK finds the company, but hard-coded details are still displayed. It's another task (involving the PTF session) to show the actual details retrieved.