### PR TITLE
Changing page.urls to use template.paths names

### DIFF
--- a/src/model/page.urls.ts
+++ b/src/model/page.urls.ts
@@ -1,7 +1,14 @@
+import * as template from "./template.paths";
+
+/**
+ * Keep template names in template.paths.ts and reference them in here for URLs
+ */
+
 export const ROOT: string = "/";
-export const PROMISE_TO_FILE: string = "/promise-to-file";
-export const COMPANY_NUMBER: string = "/company-number";
-export const CHECK_COMPANY: string = "/check-company";
+const SEPARATOR: string = "/";
+export const PROMISE_TO_FILE: string = SEPARATOR + "promise-to-file";
+export const COMPANY_NUMBER: string = SEPARATOR + template.COMPANY_NUMBER;
+export const CHECK_COMPANY: string = SEPARATOR + template.CHECK_COMPANY;
 
 export const PROMISE_TO_FILE_COMPANY_NUMBER: string = PROMISE_TO_FILE + COMPANY_NUMBER;
 export const PROMISE_TO_FILE_CHECK_COMPANY: string = PROMISE_TO_FILE + CHECK_COMPANY;

--- a/src/model/page.urls.ts
+++ b/src/model/page.urls.ts
@@ -10,5 +10,8 @@ export const PROMISE_TO_FILE: string = SEPARATOR + "promise-to-file";
 export const COMPANY_NUMBER: string = SEPARATOR + template.COMPANY_NUMBER;
 export const CHECK_COMPANY: string = SEPARATOR + template.CHECK_COMPANY;
 
+/**
+ * URLs for redirects will need to start with the application name
+ */
 export const PROMISE_TO_FILE_COMPANY_NUMBER: string = PROMISE_TO_FILE + COMPANY_NUMBER;
 export const PROMISE_TO_FILE_CHECK_COMPANY: string = PROMISE_TO_FILE + CHECK_COMPANY;


### PR DESCRIPTION
To avoid duplication of page names, I've changed page.urls to use the template names from template.paths.