### PR TITLE
Imported view form prototype UAT branch

### DIFF
--- a/views/confirmation.html
+++ b/views/confirmation.html
@@ -1,0 +1,63 @@
+{% extends "layout.html" %}
+
+<!-- Adds a class to increase vertical spacing for pages without a back button -->
+{% set mainClasses = "govuk-main-wrapper--l" %}
+
+{% block pageTitle %}
+Confirmation page
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+        <div class="govuk-panel govuk-panel--confirmation">
+            <h1 class="govuk-panel__title">You've told us
+                {{scenario.company.name}}
+                is still required</h1>
+            <div class="govuk-panel__body">
+                Your reference number is the company number<br>
+                <strong>{{ scenario.company.number }}</strong>
+            </div>
+        </div>
+
+        {% if scenario.company.PTFRequested !== 'yes' %}
+        <p class="govuk-body-l">
+            We've sent a confirmation email to
+            <span class="govuk-body-l govuk-!-font-weight-bold">{{ email }}</span>
+            which contains your reference number.
+        </p>
+        {% else %}
+        <p class="govuk-body-l">
+            We sent a confirmation email to
+            <span class="govuk-body-l govuk-!-font-weight-bold">{{ email }}</span>
+            on the
+            {{scenario.company.requestedDate }}
+            which contains your reference number.
+        </p>
+        {% endif %}
+
+        <p class="govuk-body">
+            <a href="print-confirmation" class="govuk-link">Print or save a copy of this confirmation</a>
+        </p>
+
+        <h2 class="govuk-heading-m">What happens next</h2>
+        <p>{{ scenario.company.name }}
+            will be kept on the register but it must file its accounts. It will receive a
+            <a href="https://www.gov.uk/annual-accounts/penalties-for-late-filing">late filing penalty</a>
+            that increases over time until its accounts are filed.</p>
+        <p>If the accounts are not filed we will take steps to close the company and remove it from the register from
+            {{ scenario.company.newDeadline }}</p>
+        {{ govukWarningText({
+        text: "Not filing for a company is a criminal offence. The directors of the company risk prosecution and company assets may be seized. ",
+        iconFallbackText: "Warning"
+        }) }}
+        <p class="govuk-body">
+            <a href="https://www.gov.uk/service-manual/user-centred-design/resources/patterns/feedback-pages.html" class="govuk-link">What did you think of this service?</a>
+            (takes 30 seconds)
+        </p>
+    </div>
+</div>
+
+{% endblock %}

--- a/views/confirmation.html
+++ b/views/confirmation.html
@@ -22,7 +22,7 @@ Confirmation page
             </div>
         </div>
 
-        {% if scenario.company.PTFRequested !== 'yes' %}
+        {% if scenario.company.PTFRequested !== "yes" %}
         <p class="govuk-body-l">
             We've sent a confirmation email to
             <span class="govuk-body-l govuk-!-font-weight-bold">{{ email }}</span>


### PR DESCRIPTION
Brought in html view prototype from the UAT branch of the prototype.

Spoke with Oliie about whether to split is/is no longer required into different templates - put them both in one template as both scenareos will ahve to work from the same URL.