### PR TITLE
Feature/lfa 1406 application already submitted flag

### DIFF
--- a/src/controllers/check.company.controller.ts
+++ b/src/controllers/check.company.controller.ts
@@ -1,8 +1,8 @@
 import { NextFunction, Request, Response } from "express";
 import { PTFCompanyProfile } from "../model/company.profile";
 import { Templates } from "../model/template.paths";
-import { getPromiseToFileSessionValue } from "../services/session.service";
-import { COMPANY_PROFILE } from "../session/keys";
+import { getPromiseToFileSessionValue, updatePromiseToFileSessionValue } from "../services/session.service";
+import { ALREADY_SUBMITTED, COMPANY_PROFILE } from "../session/keys";
 
 /**
  * GET controller for check company details screen
@@ -13,7 +13,7 @@ import { COMPANY_PROFILE } from "../session/keys";
 export const route = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
 
   const company: PTFCompanyProfile = getPromiseToFileSessionValue(req.chSession, COMPANY_PROFILE);
-
+  await updatePromiseToFileSessionValue(req.chSession, ALREADY_SUBMITTED, false);
   return res.render(Templates.CHECK_COMPANY, {
     company,
     templateName: Templates.CHECK_COMPANY,

--- a/src/controllers/confirmation.controller.ts
+++ b/src/controllers/confirmation.controller.ts
@@ -56,7 +56,6 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
     const token = req.chSession.accessToken() as string;
     let apiResponseData: any;
     try {
-        // TODO  LFA-1406 Add isSubmitted flag to prevent this being sent twice
 
         const axiosResponse: AxiosResponse = await callPromiseToFileAPI(companyProfile.companyNumber,
             token, isStillRequired);
@@ -77,7 +76,6 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
 
   if (isStillRequired) {
     const filingDueOn =  getPromiseToFileSessionValue(req.chSession, NEW_DEADLINE);
-    logger.debug("\n\n>>>>>>>>>>>>>>>>>>>> NEW DEADLINE " + filingDueOn + "\n\n");
     logger.debug(`New filing deadline : ${filingDueOn}`);
 
     if (!filingDueOn) {

--- a/src/controllers/confirmation.controller.ts
+++ b/src/controllers/confirmation.controller.ts
@@ -57,25 +57,25 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
     let apiResponseData: any;
     try {
 
-        const axiosResponse: AxiosResponse = await callPromiseToFileAPI(companyProfile.companyNumber,
-            token, isStillRequired);
+      const axiosResponse: AxiosResponse = await callPromiseToFileAPI(companyProfile.companyNumber,
+        token, isStillRequired);
 
-        apiResponseData = axiosResponse.data;
-        await updatePromiseToFileSessionValue(req.chSession, NEW_DEADLINE, apiResponseData.filing_due_on);
-        await updatePromiseToFileSessionValue(req.chSession, ALREADY_SUBMITTED, true);
+      apiResponseData = axiosResponse.data;
+      await updatePromiseToFileSessionValue(req.chSession, NEW_DEADLINE, apiResponseData.filing_due_on);
+      await updatePromiseToFileSessionValue(req.chSession, ALREADY_SUBMITTED, true);
 
-        logger.debug(`Response data returned from the PTF api call : ${JSON.stringify(apiResponseData)}`);
+      logger.debug(`Response data returned from the PTF api call : ${JSON.stringify(apiResponseData)}`);
     } catch (e) {
         logger.error("Error processing application " + JSON.stringify(e));
         await updatePromiseToFileSessionValue(req.chSession, ALREADY_SUBMITTED, false);
         return next(e);
     }
   } else {
-      logger.error("Form already submitted, not processing again");
+    logger.error("Form already submitted, not processing again");
   }
 
   if (isStillRequired) {
-    const filingDueOn =  getPromiseToFileSessionValue(req.chSession, NEW_DEADLINE);
+    const filingDueOn = getPromiseToFileSessionValue(req.chSession, NEW_DEADLINE);
     logger.debug(`New filing deadline : ${filingDueOn}`);
 
     if (!filingDueOn) {

--- a/src/session/keys.ts
+++ b/src/session/keys.ts
@@ -24,3 +24,5 @@ export const PTF_SESSION: string = "ptf_session";
 export const COMPANY_NUMBER: string = "company_number";
 export const COMPANY_PROFILE: string = "company_profile";
 export const IS_STILL_REQUIRED: string = "is_still_required";
+export const NEW_DEADLINE: string = "new_deadline";
+export const ALREADY_SUBMITTED: string = "already_submitted";


### PR DESCRIPTION
As well as setting the submitted flag we also require access to the new deadline in cases where the application has and hasn't been submitted for the purpose of redisplaying the confirmation page.