### PR TITLE
Feature/lfa 1612 allow single letter companies

### DIFF
--- a/src/controllers/company.number.controller.ts
+++ b/src/controllers/company.number.controller.ts
@@ -36,7 +36,6 @@ const formatCompanyNumber = (companyNumber: string, leadPoint: number, padStart:
   const leadingLetters = companyNumber.substring(0, leadPoint);
   let trailingChars = companyNumber.substring(leadPoint, companyNumber.length);
   trailingChars = trailingChars.padStart(padStart, "0");
-  logger.debug("`n >>>>>>>>>>> TRAILING CHARS: " + trailingChars);
   return leadingLetters + trailingChars;
 };
 

--- a/src/controllers/company.number.controller.ts
+++ b/src/controllers/company.number.controller.ts
@@ -21,11 +21,10 @@ const preValidators = [
 // pads company number to 8 digits with 0's and removes whitespace
 const padCompanyNumber = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   let companyNumber: string = req.body.companyNumber;
-  if (/^([a-zA-Z]{2}?)/gm.test(companyNumber)) {
-    const leadingLetters = companyNumber.substring(0, 2);
-    let trailingChars = companyNumber.substring(2, companyNumber.length);
-    trailingChars = trailingChars.padStart(6, "0");
-    companyNumber = leadingLetters + trailingChars;
+  if (/^([a-zA-Z]{1}?)/gm.test(companyNumber)) {
+    companyNumber = formatCompanyNumber(companyNumber, 1, 7);
+  } else if (/^([a-zA-Z]{2}?)/gm.test(companyNumber)) {
+    companyNumber = formatCompanyNumber(companyNumber, 2, 6);
   } else {
     companyNumber = companyNumber.padStart(8, "0");
   }
@@ -33,10 +32,18 @@ const padCompanyNumber = async (req: Request, res: Response, next: NextFunction)
   return next();
 };
 
+const formatCompanyNumber = (companyNumber: string, leadPoint: number, padStart: number): string  => {
+  const leadingLetters = companyNumber.substring(0, leadPoint);
+  let trailingChars = companyNumber.substring(leadPoint, companyNumber.length);
+  trailingChars = trailingChars.padStart(padStart, "0");
+  logger.debug("`n >>>>>>>>>>> TRAILING CHARS: " + trailingChars);
+  return leadingLetters + trailingChars;
+};
+
 // validator middleware that checks for invalid characters in the input
 const postValidators = [
   check("companyNumber").blacklist(" ").escape().custom((value: string) => {
-    if (!/^([a-zA-Z]{2})?[0-9]{6,8}$/gm.test(value)) {
+    if (!/^([a-zA-Z]{1,2})?[0-9]{6,8}$/gm.test(value)) {
       throw new Error(INVALID_COMPANY_NUMBER);
     }
     return true;

--- a/src/controllers/company.number.controller.ts
+++ b/src/controllers/company.number.controller.ts
@@ -21,10 +21,10 @@ const preValidators = [
 // pads company number to 8 digits with 0's and removes whitespace
 const padCompanyNumber = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   let companyNumber: string = req.body.companyNumber;
-  if (/^([a-zA-Z]{1}?)/gm.test(companyNumber)) {
-    companyNumber = formatCompanyNumber(companyNumber, 1, 7);
-  } else if (/^([a-zA-Z]{2}?)/gm.test(companyNumber)) {
+  if (/^([a-zA-Z]{2}?)/gm.test(companyNumber)) {
     companyNumber = formatCompanyNumber(companyNumber, 2, 6);
+  } else if (/^([a-zA-Z]{1}?)/gm.test(companyNumber)) {
+    companyNumber = formatCompanyNumber(companyNumber, 1, 7);
   } else {
     companyNumber = companyNumber.padStart(8, "0");
   }

--- a/src/controllers/company.number.controller.ts
+++ b/src/controllers/company.number.controller.ts
@@ -42,7 +42,7 @@ const formatCompanyNumber = (companyNumber: string, leadPoint: number): string  
 // validator middleware that checks for invalid characters in the input
 const postValidators = [
   check("companyNumber").blacklist(" ").escape().custom((value: string) => {
-    if (!/^([a-zA-Z]{1,2})?[0-9]{6,8}$/gm.test(value)) {
+    if (!/^[0-9]{8}$|^([a-zA-Z]{1})[0-9]{7}$|^([a-zA-Z]{2})[0-9]{6}$/gm.test(value)) {
       throw new Error(INVALID_COMPANY_NUMBER);
     }
     return true;

--- a/src/controllers/company.number.controller.ts
+++ b/src/controllers/company.number.controller.ts
@@ -22,9 +22,9 @@ const preValidators = [
 const padCompanyNumber = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   let companyNumber: string = req.body.companyNumber;
   if (/^([a-zA-Z]{2}?)/gm.test(companyNumber)) {
-    companyNumber = formatCompanyNumber(companyNumber, 2, 6);
+    companyNumber = formatCompanyNumber(companyNumber, 2);
   } else if (/^([a-zA-Z]{1}?)/gm.test(companyNumber)) {
-    companyNumber = formatCompanyNumber(companyNumber, 1, 7);
+    companyNumber = formatCompanyNumber(companyNumber, 1);
   } else {
     companyNumber = companyNumber.padStart(8, "0");
   }
@@ -32,10 +32,10 @@ const padCompanyNumber = async (req: Request, res: Response, next: NextFunction)
   return next();
 };
 
-const formatCompanyNumber = (companyNumber: string, leadPoint: number, padStart: number): string  => {
+const formatCompanyNumber = (companyNumber: string, leadPoint: number): string  => {
   const leadingLetters = companyNumber.substring(0, leadPoint);
   let trailingChars = companyNumber.substring(leadPoint, companyNumber.length);
-  trailingChars = trailingChars.padStart(padStart, "0");
+  trailingChars = trailingChars.padStart((8 - leadPoint), "0");
   return leadingLetters + trailingChars;
 };
 

--- a/test/controllers/company.number.controller.spec.unit.ts
+++ b/test/controllers/company.number.controller.spec.unit.ts
@@ -160,4 +160,49 @@ describe("company number validation tests", () => {
     expect(response.text).not.toContain(COMPANY_NUMBER_TOO_LONG);
   });
 
+  it("should pad company details for a valid abbreviated company number", async () => {
+    mockCompanyProfile.mockResolvedValue(getDummyCompanyProfile(true, true));
+
+    const response = await request(app)
+        .post(COMPANY_REQUIRED_COMPANY_NUMBER)
+        .set("Accept", "application/json")
+        .set("Referer", "/")
+        .set("Cookie", [`${COOKIE_NAME}=123`])
+        .send({companyNumber: "6400"});
+
+    expect(response.header.location).toEqual(COMPANY_REQUIRED_CHECK_COMPANY);
+    expect(response.status).toEqual(302);
+    expect(mockCompanyProfile).toHaveBeenCalledWith(COMPANY_NUMBER, ACCESS_TOKEN);
+  });
+
+  it("should pad company details for a valid abbreviated company number - single letter prefix", async () => {
+    mockCompanyProfile.mockResolvedValue(getDummyCompanyProfile(true, true));
+
+    const response = await request(app)
+        .post(COMPANY_REQUIRED_COMPANY_NUMBER)
+        .set("Accept", "application/json")
+        .set("Referer", "/")
+        .set("Cookie", [`${COOKIE_NAME}=123`])
+        .send({companyNumber: "A123"});
+
+    expect(response.header.location).toEqual(COMPANY_REQUIRED_CHECK_COMPANY);
+    expect(response.status).toEqual(302);
+    expect(mockCompanyProfile).toHaveBeenCalledWith("A0000123", ACCESS_TOKEN);
+  });
+
+  it("should pad company details for a valid abbreviated company number - double letter prefix", async () => {
+    mockCompanyProfile.mockResolvedValue(getDummyCompanyProfile(true, true));
+
+    const response = await request(app)
+        .post(COMPANY_REQUIRED_COMPANY_NUMBER)
+        .set("Accept", "application/json")
+        .set("Referer", "/")
+        .set("Cookie", [`${COOKIE_NAME}=123`])
+        .send({companyNumber: "AA123"});
+
+    expect(response.header.location).toEqual(COMPANY_REQUIRED_CHECK_COMPANY);
+    expect(response.status).toEqual(302);
+    expect(mockCompanyProfile).toHaveBeenCalledWith("AA000123", ACCESS_TOKEN);
+  });
+
 });

--- a/test/controllers/company.number.controller.spec.unit.ts
+++ b/test/controllers/company.number.controller.spec.unit.ts
@@ -129,4 +129,35 @@ describe("company number validation tests", () => {
     expect(updatePromiseToFileSessionValue).toHaveBeenCalledWith(expect.any(Session),
       COMPANY_PROFILE, getDummyCompanyProfile(true, true));
   });
+
+  it("should not throw invalid error for company with two letter prefix", async () => {
+    const response = await request(app)
+        .post(COMPANY_REQUIRED_COMPANY_NUMBER)
+        .set("Accept", "application/json")
+        .set("Referer", "/")
+        .set("Cookie", [`${COOKIE_NAME}=123`])
+        .send({companyNumber: "AB012345"});
+
+    expect(response.status).toEqual(302);
+    expect(response).not.toBeUndefined();
+    expect(response.text).not.toContain(NO_COMPANY_NUMBER_SUPPLIED);
+    expect(response.text).not.toContain(INVALID_COMPANY_NUMBER);
+    expect(response.text).not.toContain(COMPANY_NUMBER_TOO_LONG);
+  });
+
+  it("should not throw invalid error for company with one letter prefix", async () => {
+    const response = await request(app)
+        .post(COMPANY_REQUIRED_COMPANY_NUMBER)
+        .set("Accept", "application/json")
+        .set("Referer", "/")
+        .set("Cookie", [`${COOKIE_NAME}=123`])
+        .send({companyNumber: "A0123456"});
+
+    expect(response.status).toEqual(302);
+    expect(response).not.toBeUndefined();
+    expect(response.text).not.toContain(NO_COMPANY_NUMBER_SUPPLIED);
+    expect(response.text).not.toContain(INVALID_COMPANY_NUMBER);
+    expect(response.text).not.toContain(COMPANY_NUMBER_TOO_LONG);
+  });
+
 });


### PR DESCRIPTION
Allow companies with single letetr prefix to access company details - changed the regex to allow 1 or 2.

Changed padding to check for two letter prefixes first (as two letters are considered to be 1 lettered as well by regex) if not code checks for 1 letetr and pads.

Unit tests for new regex validation and for the padding.