### PR TITLE
Amended confirmation not required screen and added unit tests.

### DIFF
--- a/src/controllers/confirmation.controller.ts
+++ b/src/controllers/confirmation.controller.ts
@@ -121,7 +121,8 @@ const getOverdueFiling = ({isAccountsOverdue, isConfirmationStatementOverdue}): 
   } else if (isAccountsOverdue && isConfirmationStatementOverdue) {
     overdueFiling = "accounts and confirmation statement";
   } else if (!isAccountsOverdue && !isConfirmationStatementOverdue) {
-    overdueFiling = "no open compliance case";
+    // TODO handle this output with appropriate render when story is created.
+    overdueFiling = "nothing overdue";
   }
 
   return overdueFiling;

--- a/src/controllers/confirmation.controller.ts
+++ b/src/controllers/confirmation.controller.ts
@@ -109,7 +109,7 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
     return res.render(Templates.CONFIRMATION_NOT_REQUIRED,
       {
         company: companyProfile,
-        overdueFiling: (companyProfile.isAccountsOverdue) ? "accounts" : "confirmation statement",
+        overdueFiling: getOverdueFiling(companyProfile),
         userEmail: email,
       });
   }

--- a/test/controllers/check.company.controller.spec.unit.ts
+++ b/test/controllers/check.company.controller.spec.unit.ts
@@ -26,7 +26,7 @@ describe("check company tests", () => {
     const mockGetPromiseToFileSessionValue = getPromiseToFileSessionValue as jest.Mock;
 
     mockGetPromiseToFileSessionValue.mockReset();
-    mockGetPromiseToFileSessionValue.mockImplementation(() => getDummyCompanyProfile(true, true));
+    mockGetPromiseToFileSessionValue.mockImplementation(() => getDummyCompanyProfile(true, true, true));
 
     const response = await request(app).get(COMPANY_REQUIRED_CHECK_COMPANY)
       .set("Referer", "/")

--- a/test/controllers/company.number.controller.spec.unit.ts
+++ b/test/controllers/company.number.controller.spec.unit.ts
@@ -113,7 +113,7 @@ describe("company number validation tests", () => {
   });
 
   it("should redirect to the check company details screen when company is found", async () => {
-    mockCompanyProfile.mockResolvedValue(getDummyCompanyProfile(true, true));
+    mockCompanyProfile.mockResolvedValue(getDummyCompanyProfile(true, true, true));
 
     const response = await request(app)
       .post(COMPANY_REQUIRED_COMPANY_NUMBER)
@@ -127,7 +127,7 @@ describe("company number validation tests", () => {
     expect(mockCompanyProfile).toHaveBeenCalledWith(COMPANY_NUMBER, ACCESS_TOKEN);
     expect(updatePromiseToFileSessionValue).toHaveBeenCalledTimes(1);
     expect(updatePromiseToFileSessionValue).toHaveBeenCalledWith(expect.any(Session),
-      COMPANY_PROFILE, getDummyCompanyProfile(true, true));
+      COMPANY_PROFILE, getDummyCompanyProfile(true, true, true));
   });
 
   it("should not throw invalid error for company with two letter prefix", async () => {
@@ -161,7 +161,7 @@ describe("company number validation tests", () => {
   });
 
   it("should pad company details for a valid abbreviated company number", async () => {
-    mockCompanyProfile.mockResolvedValue(getDummyCompanyProfile(true, true));
+    mockCompanyProfile.mockResolvedValue(getDummyCompanyProfile(true, true, true));
 
     const response = await request(app)
         .post(COMPANY_REQUIRED_COMPANY_NUMBER)
@@ -176,7 +176,7 @@ describe("company number validation tests", () => {
   });
 
   it("should pad company details for a valid abbreviated company number - single letter prefix", async () => {
-    mockCompanyProfile.mockResolvedValue(getDummyCompanyProfile(true, true));
+    mockCompanyProfile.mockResolvedValue(getDummyCompanyProfile(true, true, true));
 
     const response = await request(app)
         .post(COMPANY_REQUIRED_COMPANY_NUMBER)
@@ -191,7 +191,7 @@ describe("company number validation tests", () => {
   });
 
   it("should pad company details for a valid abbreviated company number - double letter prefix", async () => {
-    mockCompanyProfile.mockResolvedValue(getDummyCompanyProfile(true, true));
+    mockCompanyProfile.mockResolvedValue(getDummyCompanyProfile(true, true, true));
 
     const response = await request(app)
         .post(COMPANY_REQUIRED_COMPANY_NUMBER)

--- a/test/controllers/confirmation.controller.spec.unit.ts
+++ b/test/controllers/confirmation.controller.spec.unit.ts
@@ -28,15 +28,14 @@ describe("Company no longer required confirmation screen tests", () => {
 
   const mockCacheService = loadSession as jest.Mock;
   const mockPTFSession =  getPromiseToFileSessionValue as jest.Mock;
-  const mockActiveFeature = activeFeature as jest.Mock;
   const mockCallProcessorApi = callPromiseToFileAPI as jest.Mock;
 
-  it("should render the confirmation no longer required page", async () => {
+  it("should render the confirmation no longer required page (AA overdue)", async () => {
     mockCacheService.mockClear();
     mockPTFSession.mockClear();
     mockCallProcessorApi.mockClear();
     loadCompanyAuthenticatedSession(mockCacheService, COMPANY_NUMBER, EMAIL);
-    mockPTFSession.mockImplementationOnce(() => getDummyCompanyProfile(true, true));
+    mockPTFSession.mockImplementationOnce(() => getDummyCompanyProfile(true, false, true));
     mockPTFSession.mockImplementationOnce(() => false);
 
     mockCallProcessorApi.prototype.constructor.mockImplementationOnce(() => Promise.resolve((
@@ -53,17 +52,90 @@ describe("Company no longer required confirmation screen tests", () => {
 
     expect(resp.status).toEqual(200);
     expect(resp.text).toContain(COMPANY_NAME);
-    expect(resp.text).not.toContain(COMPANY_NUMBER);
+    expect(resp.text).toContain(COMPANY_NUMBER);
     expect(resp.text).toContain(EMAIL);
+    expect(resp.text).toContain("is no longer required");
+    expect(resp.text).toContain("we will no longer pursue the overdue accounts.");
+    expect(resp.text).not.toContain("we will no longer pursue the overdue confirmation statement.");
+    expect(resp.text).not.toContain("we will no longer pursue the overdue accounts and confirmation statement.");
     expect(resp.text).toContain(PAGE_TITLE);
   });
+
+  it("should render the confirmation no longer required page (CS overdue)", async () => {
+    mockCacheService.mockClear();
+    mockPTFSession.mockClear();
+    mockCallProcessorApi.mockClear();
+    loadCompanyAuthenticatedSession(mockCacheService, COMPANY_NUMBER, EMAIL);
+    mockPTFSession.mockImplementationOnce(() => getDummyCompanyProfile(false, true, true));
+    mockPTFSession.mockImplementationOnce(() => false);
+
+    mockCallProcessorApi.prototype.constructor.mockImplementationOnce(() => Promise.resolve((
+      {
+        data: {},
+      } )));
+
+    const resp = await request(app)
+      .get(URL)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
+
+    expect(mockCallProcessorApi).toBeCalled();
+
+    expect(resp.status).toEqual(200);
+    expect(resp.text).toContain(COMPANY_NAME);
+    expect(resp.text).toContain(COMPANY_NUMBER);
+    expect(resp.text).toContain(EMAIL);
+    expect(resp.text).toContain("is no longer required");
+    expect(resp.text).not.toContain("we will no longer pursue the overdue accounts.");
+    expect(resp.text).toContain("we will no longer pursue the overdue confirmation statement.");
+    expect(resp.text).not.toContain("we will no longer pursue the overdue accounts and confirmation statement.");
+    expect(resp.text).toContain(PAGE_TITLE);
+  });
+
+  it("should render the confirmation no longer required page (AA and CS overdue)", async () => {
+    mockCacheService.mockClear();
+    mockPTFSession.mockClear();
+    mockCallProcessorApi.mockClear();
+    loadCompanyAuthenticatedSession(mockCacheService, COMPANY_NUMBER, EMAIL);
+    mockPTFSession.mockImplementationOnce(() => getDummyCompanyProfile(true, true, true));
+    mockPTFSession.mockImplementationOnce(() => false);
+
+    mockCallProcessorApi.prototype.constructor.mockImplementationOnce(() => Promise.resolve((
+      {
+        data: {},
+      } )));
+
+    const resp = await request(app)
+      .get(URL)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
+
+    expect(mockCallProcessorApi).toBeCalled();
+
+    expect(resp.status).toEqual(200);
+    expect(resp.text).toContain(COMPANY_NAME);
+    expect(resp.text).toContain(COMPANY_NUMBER);
+    expect(resp.text).toContain(EMAIL);
+    expect(resp.text).toContain("is no longer required");
+    expect(resp.text).not.toContain("we will no longer pursue the overdue accounts.");
+    expect(resp.text).not.toContain("we will no longer pursue the overdue confirmation statement.");
+    expect(resp.text).toContain("we will no longer pursue the overdue accounts and confirmation statement.");
+    expect(resp.text).toContain(PAGE_TITLE);
+  });
+});
+
+describe("Confirmation stub screen tests", () => {
+
+  const mockCacheService = loadSession as jest.Mock;
+  const mockPTFSession =  getPromiseToFileSessionValue as jest.Mock;
+  const mockCallProcessorApi = callPromiseToFileAPI as jest.Mock;
 
   it("should render the confirmation stub page (england-wales)", async () => {
     mockCacheService.mockClear();
     mockPTFSession.mockClear();
     mockCallProcessorApi.mockClear();
     loadCompanyAuthenticatedSession(mockCacheService, COMPANY_NUMBER, EMAIL);
-    const dummyProfile = getDummyCompanyProfile(true, true);
+    const dummyProfile = getDummyCompanyProfile(true, true, true);
     mockPTFSession.mockImplementationOnce(() => dummyProfile);
     mockPTFSession.mockImplementationOnce(() => true);
     const resp = await request(app)
@@ -86,7 +158,7 @@ describe("Company no longer required confirmation screen tests", () => {
     mockPTFSession.mockClear();
     mockCallProcessorApi.mockClear();
     loadCompanyAuthenticatedSession(mockCacheService, COMPANY_NUMBER, EMAIL);
-    const dummyProfile = getDummyCompanyProfile(true, true);
+    const dummyProfile = getDummyCompanyProfile(true, true, true);
     dummyProfile.jurisdiction = SCOTLAND;
     mockPTFSession.mockImplementationOnce(() => dummyProfile);
     mockPTFSession.mockImplementationOnce(() => true);
@@ -110,7 +182,7 @@ describe("Company no longer required confirmation screen tests", () => {
     mockPTFSession.mockClear();
     mockCallProcessorApi.mockClear();
     loadCompanyAuthenticatedSession(mockCacheService, COMPANY_NUMBER, EMAIL);
-    const dummyProfile = getDummyCompanyProfile(true, true);
+    const dummyProfile = getDummyCompanyProfile(true, true, true);
     dummyProfile.jurisdiction = NORTHERN_IRELAND;
     mockPTFSession.mockImplementationOnce(() => dummyProfile);
     mockPTFSession.mockImplementationOnce(() => true);
@@ -128,6 +200,14 @@ describe("Company no longer required confirmation screen tests", () => {
     expect(resp.text).toContain("BT2 8BG");
     expect(resp.text).toContain(PAGE_TITLE);
   });
+});
+
+describe("Company still required confirmation screen tests", () => {
+
+  const mockCacheService = loadSession as jest.Mock;
+  const mockPTFSession =  getPromiseToFileSessionValue as jest.Mock;
+  const mockActiveFeature = activeFeature as jest.Mock;
+  const mockCallProcessorApi = callPromiseToFileAPI as jest.Mock;
 
   it("should render the confirmation still required page when feature flag is true", async () => {
 
@@ -136,7 +216,7 @@ describe("Company no longer required confirmation screen tests", () => {
     mockActiveFeature.mockClear();
     mockCallProcessorApi.mockClear();
     loadCompanyAuthenticatedSession(mockCacheService, COMPANY_NUMBER, EMAIL);
-    const dummyProfile = getDummyCompanyProfile(true, true);
+    const dummyProfile = getDummyCompanyProfile(true, true, true);
     mockPTFSession.mockImplementationOnce(() => dummyProfile);
     mockPTFSession.mockImplementationOnce(() => true);
     mockActiveFeature.mockImplementationOnce(() => true);
@@ -172,7 +252,7 @@ describe("Company no longer required confirmation screen tests", () => {
     mockActiveFeature.mockClear();
     mockCallProcessorApi.mockClear();
     loadCompanyAuthenticatedSession(mockCacheService, COMPANY_NUMBER, EMAIL);
-    const dummyProfile = getDummyCompanyProfile(true, true);
+    const dummyProfile = getDummyCompanyProfile(true, true, true);
 
     dummyProfile.isConfirmationStatementOverdue = false;
 
@@ -205,7 +285,7 @@ describe("Company no longer required confirmation screen tests", () => {
     mockActiveFeature.mockClear();
     mockCallProcessorApi.mockClear();
     loadCompanyAuthenticatedSession(mockCacheService, COMPANY_NUMBER, EMAIL);
-    const dummyProfile = getDummyCompanyProfile(true, true);
+    const dummyProfile = getDummyCompanyProfile(true, true, true);
 
     dummyProfile.isAccountsOverdue = false;
 
@@ -239,7 +319,7 @@ describe("Company no longer required confirmation screen tests", () => {
     mockActiveFeature.mockClear();
     mockCallProcessorApi.mockRestore();
     loadCompanyAuthenticatedSession(mockCacheService, COMPANY_NUMBER, EMAIL);
-    const dummyProfile = getDummyCompanyProfile(true, true);
+    const dummyProfile = getDummyCompanyProfile(true, true, true);
     mockPTFSession.mockImplementationOnce(() => dummyProfile);
     mockPTFSession.mockImplementationOnce(() => true);
     mockActiveFeature.mockImplementationOnce(() => true);
@@ -275,7 +355,7 @@ describe("Company no longer required confirmation screen tests", () => {
     mockActiveFeature.mockClear();
     mockCallProcessorApi.mockRestore();
     loadCompanyAuthenticatedSession(mockCacheService, COMPANY_NUMBER, EMAIL);
-    const dummyProfile = getDummyCompanyProfile(true, true);
+    const dummyProfile = getDummyCompanyProfile(true, true, true);
     mockPTFSession.mockImplementationOnce(() => dummyProfile);
     mockPTFSession.mockImplementationOnce(() => true);
     mockActiveFeature.mockImplementationOnce(() => true);
@@ -311,7 +391,7 @@ describe("Company no longer required confirmation screen tests", () => {
       mockActiveFeature.mockClear();
       mockCallProcessorApi.mockRestore();
       loadCompanyAuthenticatedSession(mockCacheService, COMPANY_NUMBER, EMAIL);
-      const dummyProfile = getDummyCompanyProfile(true, true);
+      const dummyProfile = getDummyCompanyProfile(true, true, true);
       mockPTFSession.mockImplementationOnce(() => dummyProfile);
       mockPTFSession.mockImplementationOnce(() => true);
       mockActiveFeature.mockImplementationOnce(() => true);
@@ -347,7 +427,7 @@ describe("Company no longer required confirmation screen tests", () => {
       mockActiveFeature.mockClear();
       mockCallProcessorApi.mockRestore();
       loadCompanyAuthenticatedSession(mockCacheService, COMPANY_NUMBER, EMAIL);
-      const dummyProfile = getDummyCompanyProfile(true, true);
+      const dummyProfile = getDummyCompanyProfile(true, true, true);
       mockPTFSession.mockImplementationOnce(() => dummyProfile);
       mockPTFSession.mockImplementationOnce(() => true);
       mockActiveFeature.mockImplementationOnce(() => true);
@@ -382,7 +462,7 @@ describe("Company no longer required confirmation screen tests", () => {
     mockActiveFeature.mockClear();
     mockCallProcessorApi.mockClear();
     loadCompanyAuthenticatedSession(mockCacheService, COMPANY_NUMBER, EMAIL);
-    const dummyProfile = getDummyCompanyProfile(false, true);
+    const dummyProfile = getDummyCompanyProfile(false, false, true);
 
     mockPTFSession.mockImplementationOnce(() => dummyProfile);
     mockPTFSession.mockImplementationOnce(() => true);
@@ -439,7 +519,7 @@ describe("Company no longer required confirmation screen tests", () => {
     mockActiveFeature.mockClear();
     mockCallProcessorApi.mockClear();
     loadCompanyAuthenticatedSession(mockCacheService, COMPANY_NUMBER, EMAIL);
-    const dummyProfile = getDummyCompanyProfile(true, true);
+    const dummyProfile = getDummyCompanyProfile(true, true, true);
     mockPTFSession.mockImplementationOnce(() => dummyProfile);
     mockPTFSession.mockImplementationOnce(() => true);
     mockActiveFeature.mockImplementationOnce(() => true);
@@ -475,7 +555,7 @@ describe("Company no longer required confirmation screen tests", () => {
     mockActiveFeature.mockClear();
     mockCallProcessorApi.mockClear();
     loadCompanyAuthenticatedSession(mockCacheService, COMPANY_NUMBER, EMAIL);
-    const dummyProfile = getDummyCompanyProfile(true, true);
+    const dummyProfile = getDummyCompanyProfile(true, true, true);
     mockPTFSession.mockImplementationOnce(() => dummyProfile);
     mockPTFSession.mockImplementationOnce(() => true);
     mockActiveFeature.mockImplementationOnce(() => true);

--- a/test/controllers/confirmation.controller.spec.unit.ts
+++ b/test/controllers/confirmation.controller.spec.unit.ts
@@ -24,11 +24,12 @@ const ERROR_PAGE: string = "Sorry, there is a problem with the service";
 const SCOTLAND: string = "scotland";
 const NORTHERN_IRELAND: string = "northern-ireland";
 
-describe("Company no longer required confirmation screen tests", () => {
+const mockCacheService = loadSession as jest.Mock;
+const mockPTFSession =  getPromiseToFileSessionValue as jest.Mock;
+const mockActiveFeature = activeFeature as jest.Mock;
+const mockCallProcessorApi = callPromiseToFileAPI as jest.Mock;
 
-  const mockCacheService = loadSession as jest.Mock;
-  const mockPTFSession =  getPromiseToFileSessionValue as jest.Mock;
-  const mockCallProcessorApi = callPromiseToFileAPI as jest.Mock;
+describe("Company no longer required confirmation screen tests", () => {
 
   it("should render the confirmation no longer required page (AA overdue)", async () => {
     mockCacheService.mockClear();
@@ -126,10 +127,6 @@ describe("Company no longer required confirmation screen tests", () => {
 
 describe("Confirmation stub screen tests", () => {
 
-  const mockCacheService = loadSession as jest.Mock;
-  const mockPTFSession =  getPromiseToFileSessionValue as jest.Mock;
-  const mockCallProcessorApi = callPromiseToFileAPI as jest.Mock;
-
   it("should render the confirmation stub page (england-wales)", async () => {
     mockCacheService.mockClear();
     mockPTFSession.mockClear();
@@ -203,11 +200,6 @@ describe("Confirmation stub screen tests", () => {
 });
 
 describe("Company still required confirmation screen tests", () => {
-
-  const mockCacheService = loadSession as jest.Mock;
-  const mockPTFSession =  getPromiseToFileSessionValue as jest.Mock;
-  const mockActiveFeature = activeFeature as jest.Mock;
-  const mockCallProcessorApi = callPromiseToFileAPI as jest.Mock;
 
   it("should render the confirmation still required page when feature flag is true", async () => {
 
@@ -417,7 +409,7 @@ describe("Company still required confirmation screen tests", () => {
       expect(resp.text).toContain("We've already been told that THE GIRLS DAY SCHOOL TRUST is still required.");
       expect(resp.text).not.toContain("The company THE GIRLS DAY SCHOOL TRUST has no appointed directors.");
       expect(resp.text).toContain(NOT_ELIGIBLE_PAGE_TITLE);
-    });
+  });
 
   it("should render the not eligible page (no appointed directors) when reason code is NO_DIRECTORS",
     async () => {
@@ -453,43 +445,6 @@ describe("Company still required confirmation screen tests", () => {
       expect(resp.text).not.toContain("We've already been told that THE GIRLS DAY SCHOOL TRUST is still required.");
       expect(resp.text).toContain("The company THE GIRLS DAY SCHOOL TRUST has no appointed directors.");
       expect(resp.text).toContain(NOT_ELIGIBLE_PAGE_TITLE);
-    });
-
-  it("should render the error page when company still required but neither accounts or confirmation statement are overdue", async () => {
-
-    mockCacheService.mockClear();
-    mockPTFSession.mockClear();
-    mockActiveFeature.mockClear();
-    mockCallProcessorApi.mockClear();
-    loadCompanyAuthenticatedSession(mockCacheService, COMPANY_NUMBER, EMAIL);
-    const dummyProfile = getDummyCompanyProfile(false, false, true);
-
-    mockPTFSession.mockImplementationOnce(() => dummyProfile);
-    mockPTFSession.mockImplementationOnce(() => true);
-    mockActiveFeature.mockImplementationOnce(() => true);
-
-    mockCallProcessorApi.prototype.constructor.mockImplementationOnce(() => Promise.resolve((
-      {
-        data: {
-          filing_due_on: "2028-03-10",
-        },
-      } )));
-
-    const resp = await request(app)
-      .get(URL)
-      .set("Referer", "/")
-      .set("Cookie", [`${COOKIE_NAME}=123`]);
-
-    expect(mockCallProcessorApi).toBeCalled();
-
-    expect(resp.status).toEqual(500);
-    expect(resp.text).not.toContain(EMAIL);
-    expect(resp.text).not.toContain(COMPANY_NAME);
-    expect(resp.text).not.toContain(COMPANY_NUMBER);
-    expect(resp.text).not.toContain(PAGE_TITLE);
-    expect(resp.text).not.toContain("must file its");
-    expect(resp.text).not.toContain("filed by");
-    expect(resp.text).toContain(ERROR_PAGE);
   });
 
   it("should return the error page if email is missing from session", async () => {

--- a/test/controllers/still.required.controllers.spec.unit.ts
+++ b/test/controllers/still.required.controllers.spec.unit.ts
@@ -23,7 +23,7 @@ describe("still required validation and session tests", () => {
     loadMockSession(mockCacheService);
     loadCompanyAuthenticatedSession(mockCacheService, "00006400");
     mockGetPromiseToFileSessionValue.mockReset();
-    mockGetPromiseToFileSessionValue.mockImplementation(() => getDummyCompanyProfile(true, true));
+    mockGetPromiseToFileSessionValue.mockImplementation(() => getDummyCompanyProfile(true, true, true));
 
     const response = await request(app)
       .post("/company-required/company/00006400/still-required")

--- a/test/mock.utils.ts
+++ b/test/mock.utils.ts
@@ -70,7 +70,7 @@ export const ACCOUNTS_NEXT_DUE_DATE = "2019-05-12";
 export const CONFIRMATION_STATEMENT_NEXT_DUE_DATE = "2019-09-03";
 export const JURISDICTION = "england-wales";
 
-export const getDummyCompanyProfile = (isOverdue: boolean, isActive): PTFCompanyProfile => {
+export const getDummyCompanyProfile = (isAAOverdue: boolean, isCSOverdue: boolean, isActive): PTFCompanyProfile => {
   return {
     accountingPeriodEndOn: ACCOUNTS_NEXT_DUE_DATE,
     accountingPeriodStartOn: ACCOUNTS_NEXT_DUE_DATE,
@@ -86,8 +86,8 @@ export const getDummyCompanyProfile = (isOverdue: boolean, isActive): PTFCompany
     companyType: COMPANY_TYPE,
     confirmationStatementDue: CONFIRMATION_STATEMENT_NEXT_DUE_DATE,
     incorporationDate: COMPANY_INC_DATE,
-    isAccountsOverdue: isOverdue,
-    isConfirmationStatementOverdue: isOverdue,
+    isAccountsOverdue: isAAOverdue,
+    isConfirmationStatementOverdue: isCSOverdue,
     jurisdiction: JURISDICTION,
   };
 };

--- a/views/confirmation-not-required.html
+++ b/views/confirmation-not-required.html
@@ -33,7 +33,7 @@
 
         <p>If you do not close the company and do not file your overdue {{ overdueFiling }}, we may prosecute the company directors.</p>
 
-        {% if (overdueFiling === 'accounts') or (overdueFiling === 'accounts and confirmation statement') %}
+        {% if showLFPWarning %}
         <p>If {{ company.companyName }} files its accounts, it will receive a
             <a href="https://www.gov.uk/annual-accounts/penalties-for-late-filing" class="govuk-link">late filing penalty</a>
             that increases over time until the company is closed.

--- a/views/confirmation-not-required.html
+++ b/views/confirmation-not-required.html
@@ -12,8 +12,12 @@
     <div class="govuk-grid-column-two-thirds">
         <div class="govuk-panel govuk-panel--confirmation">
             <h1 class="govuk-panel__title">You've told us
-                {{company.companyName}}
+                {{ company.companyName }}
                 is no longer required</h1>
+            <div class="govuk-panel__body">
+                Your reference number is the company number<br>
+                <strong>{{ company.companyNumber }}</strong>
+            </div>
         </div>
         <p class="govuk-body-l">
             We've sent a confirmation email to
@@ -24,16 +28,17 @@
         <h2 class="govuk-heading-m">What happens next</h2>
         <p>You should
             <a href="http://resources.companieshouse.gov.uk/close-a-company/index.html">close the company</a>
-            so that it is removed from the register. You do not need to file the
-            {{ overdueFiling }}
-            before closing the company.</p>
+            so that it is removed from the register. When you have closed the company, we will no longer pursue the overdue {{ overdueFiling }}.
         </p>
 
-        <p>
-            {{company.companyName}}
-            will receive a
-            <a href="https://www.gov.uk/annual-accounts/penalties-for-late-filing">late filing penalty</a>
-            that increases over time until the company is closed.</p>
+        <p>If you do not close the company and do not file your overdue {{ overdueFiling }}, we may prosecute the company directors.</p>
+
+        {% if (overdueFiling === 'accounts') or (overdueFiling === 'accounts and confirmation statement') %}
+        <p>If {{ company.companyName }} files its accounts, it will receive a
+            <a href="https://www.gov.uk/annual-accounts/penalties-for-late-filing" class="govuk-link">late filing penalty</a>
+            that increases over time until the company is closed.
+        </p>
+        {% endif %}
 
         <p class="govuk-body">
             <a href="https://www.research.net/r/ptf-confirmation" class="govuk-link">What did you think of this service?</a>


### PR DESCRIPTION
Jira tickets at: https://companieshouse.atlassian.net/browse/LFA-1530
                        https://companieshouse.atlassian.net/browse/LFA-1531
                        https://companieshouse.atlassian.net/browse/LFA-1532

Additional unit tests are to accommodate for the variations in the confirmation screen. Also split up the tests for the different confirmation pages.

Updated mock utils getDummyCompanyProfile function to allow setting the confirmation overdue variable separately for more specific screen testing.

