### PR TITLE
Improve test coverage by excluding bin directory

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.password=${env.CODE_ANALYSIS_PASSWORD}
 sonar.sources=src,views
 
 sonar.projectName=promise-to-file-web
-sonar.exclusions=**/dist/**, **/coverage/**, **/node_modules/**
+sonar.exclusions=**/bin/**, **/dist/**, **/coverage/**, **/node_modules/**
 sonar.tests=test
 sonar.test.inclusions=**/test/**.spec.*
 sonar.typescript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
Can improve sonar coverage by excluding the bin directory as we do for extensions-web.