### PR TITLE
set no opener and no referrer on links that open in a new tab

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -14,7 +14,7 @@
     tag: {
       text: "beta"
     },
-    html: 'This is a new service - Help us improve it by providing <a class="govuk-link" href="https://www.research.net/r/ptf-feedback" target="_blank">feedback <span class="govuk-visually-hidden">(This link opens in a new window)</span></a>'
+    html: 'This is a new service - Help us improve it by providing <a class="govuk-link" href="https://www.research.net/r/ptf-feedback" rel="noopener noreferrer" target="_blank">feedback <span class="govuk-visually-hidden">(This link opens in a new window)</span></a>'
   }) }}
   <div class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
@@ -58,7 +58,7 @@
       <h2 class="govuk-heading-m">Before you start</h2>
       <p>
         You should
-        <a href="https://www.gov.uk/government/publications/life-of-a-company-annual-requirements/life-of-a-company-part-1-accounts#penalties-for-failing-to-file-accounts" target="_blank">read the guidance on late filing penalties</a>.
+        <a href="https://www.gov.uk/government/publications/life-of-a-company-annual-requirements/life-of-a-company-part-1-accounts#penalties-for-failing-to-file-accounts" rel="noopener noreferrer" target="_blank">read the guidance on late filing penalties</a>.
       </p>
       <p>You'll need:
         <ul class="govuk-list govuk-list--bullet">

--- a/views/layout.html
+++ b/views/layout.html
@@ -57,7 +57,7 @@
     tag: {
       text: "beta"
     },
-    html: 'This is a new service - Help us improve it by providing <a class="govuk-link" href="https://www.research.net/r/ptf-feedback" target="_blank">feedback <span class="govuk-visually-hidden">(This link opens in a new window)</span></a>'
+    html: 'This is a new service - Help us improve it by providing <a class="govuk-link" href="https://www.research.net/r/ptf-feedback" rel="noopener noreferrer" target="_blank">feedback <span class="govuk-visually-hidden">(This link opens in a new window)</span></a>'
   }) }}
   <div id="templateName" data-id='{{templateName}}' hidden></div>
   {% block backLink %}


### PR DESCRIPTION
From Sonar: When a link opens a URL in a new tab with target="_blank", it is very simple for the opened page to change the location of the original page because the JavaScript variable window.opener is not null and thus "window.opener.location can be set by the opened page. This exposes the user to very simple phishing attacks.