### PR TITLE
Correct staging cdn host

### DIFF
--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -2,7 +2,7 @@ environment = "staging"
 aws_profile = "staging-eu-west-2"
 
 api_url = "https://api.staging.aws.chdev.org"
-cdn_host = "d3uvya5a8a1ncx.cloudfront.net"
+cdn_host = "https://d6nh3dxv55e16.cloudfront.net"
 chs_url = "https://staging.aws.chdev.org"
 company_still_required_feature_flag = "true"
 cookie_domain = "staging.aws.chdev.org"


### PR DESCRIPTION
This pr corrects the value of the staging cdn host in the configs. https is included to tell the browser this is the site domain.